### PR TITLE
feat: de-duplicate queued messages for not-yet-open channel

### DIFF
--- a/docs/react.md
+++ b/docs/react.md
@@ -60,7 +60,7 @@ if (channel.isOpen()) {
 
 > Note: if you or another MUPPET client attempts to send events over a channel before a receiving client is connected, the events will be temporarily held in an in-memory queue in the sender's app (will not disappear).
 >
-> As soon as both apps have connected to the same MuppetChannel, all of these pending events will be "replayed"--sent over the channel--so the receiver can receive them.
+> As soon as both apps have connected to the same MuppetChannel, all of these pending events will be "replayed"--sent over the channel--so the receiver can receive them. Any queued messages with the same `destination` and `eventClass` will be de-duplicated--using only the latest one--to avoid jittery behavior in the receiver when it comes online.
 
 ## Hooks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noaa-gsl/idsse-muppet",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@noaa-gsl/idsse-muppet",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@thumbmarkjs/thumbmarkjs": "0.14.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noaa-gsl/idsse-muppet",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Connect to, send, and receive data over MUPPET data channels in convenient React interfaces using the MUPPETs protocol",
   "main": "index.js",
   "scripts": {

--- a/src/MuppetChannel.js
+++ b/src/MuppetChannel.js
@@ -319,7 +319,7 @@ class MuppetChannel {
 
       // de-duplicate queue, so recipient app won't try to process successive state changes when it comes online
       this.#queuedMessages = this.#queuedMessages.filter(
-        (it) => it.eventClass !== data.eventClass && it.destination !== it.destination,
+        (it) => !(it.eventClass === data.eventClass && it.destination === it.destination),
       );
       this.#queuedMessages.push(data); // stash this message until channel opens (hopefully)
       return false;


### PR DESCRIPTION
### Checklist
- [x] Version number incremented in `package.json`
- [x] Unit tests are passing

### Changes
<!-- Brief description of changes -->
- For queued messages that are waiting for a MUPPET channel to open, de-duplicate messages (on `destination` and `eventClass`), only saving the most recent message

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
This protects receiving channels (apps) from jittery behavior when they do come online and connect via MUPPET/WebRTC. 

E.g. if a sender fires multiple messages with `eventClass: 'SENDER_APP.USER_SELECTED'` before a receiving app is online, the receiver would previously attempt to process all these messages, which could lead to a jumpy user experience/UI state. Now only the most recent message will take effect in the receiver.